### PR TITLE
Psb: sanitize `ImageMetadata.Name` to prevent invalid file name error

### DIFF
--- a/FreeMote.Psb/Resources/ImageMetadata.cs
+++ b/FreeMote.Psb/Resources/ImageMetadata.cs
@@ -319,6 +319,12 @@ namespace FreeMote.Psb
         /// <returns></returns>
         public string GetFriendlyName(PsbType type)
         {
+            if (!string.IsNullOrWhiteSpace(Name))
+            {
+                //Sanitize file name for export
+                Name = string.Join("_", Name.Split(Path.GetInvalidFileNameChars()));
+            }
+
             if (type == PsbType.Pimg && !string.IsNullOrWhiteSpace(Name))
             {
                 return Path.GetFileNameWithoutExtension(Name);


### PR DESCRIPTION
some `.mtn` files use strings like `src/normal/通常|キャラ|通常来海 (結合)` as its images' name, which causes an error while we are trying to export them. 
I add a check to `GetFriendlyName` to replace these invalid characters with `_`.