### PR TITLE
fix: Fix output path

### DIFF
--- a/FreeMote.PsBuild/PsbDecompiler.cs
+++ b/FreeMote.PsBuild/PsbDecompiler.cs
@@ -575,7 +575,7 @@ namespace FreeMote.PsBuild
                     //Write resx.json
                     //resx.Context[Context_ArchiveSource] = new List<string> {name};
                     //File.WriteAllText(Path.GetFullPath(filePath) + ".resx.json", resx.SerializeToJson());
-                    context[Context_ArchiveSource] = new List<string> {name};
+                    context[Context_ArchiveSource] = new List<string> { name };
                     OutputResources(psb, FreeMount.CreateContext(context), outputBasePath, PsbExtractOption.Extract);
                     return; //comment this if you need to debug without body
                 }
@@ -831,7 +831,7 @@ namespace FreeMote.PsBuild
                             File.WriteAllBytes(rawPath, bodyBytes);
                             continue;
                         }
-                        
+
                         MPack.IsSignatureMPack(bodyBytes, out var shellType);
                         var possibleFileNames = PsbExtension.ArchiveInfo_GetAllPossibleFileNames(pair.Key, suffix);
                         var relativePath = pair.Key;
@@ -936,12 +936,12 @@ namespace FreeMote.PsBuild
                             ArrayPool<byte>.Shared.Return(mdfDecompressed);
                         }
                     }
-                    
+
                     specialItemFileNames.AddRange(archiveItemFileNames.Values);
                 }
 
                 //Write resx.json
-                resx.Context[Context_ArchiveSource] = new List<string> {name};
+                resx.Context[Context_ArchiveSource] = new List<string> { name };
                 resx.Context[Context_MdfMtKey] = key;
                 resx.Context[Context_MdfKey] = archiveMdfKey;
                 resx.Context[Context_ArchiveItemFileNames] = specialItemFileNames;
@@ -951,7 +951,7 @@ namespace FreeMote.PsBuild
                     resx.Context[Context_BodyBinName] = bodyBinName;
                 }
 
-                File.WriteAllText(Path.GetFullPath(filePath) + ".resx.json", resx.SerializeToJson());
+                File.WriteAllText(outputBasePath + ".resx.json", resx.SerializeToJson());
             }
             catch (Exception e)
             {

--- a/FreeMote.Tools.PsBuild/Program.cs
+++ b/FreeMote.Tools.PsBuild/Program.cs
@@ -200,6 +200,8 @@ Example:
                     "Keep all sources raw (don't compile jsons or pack MDF shell)", CommandOptionType.NoValue);
                 var optBodyBinName = archiveCmd.Option<string>("-b|--body <NAME>",
                     "Set body.bin file name (cannot be path). Default={xxx}_body.bin", CommandOptionType.SingleValue);
+                var optOutputPath =
+                 archiveCmd.Option<string>("-o|--output", "Set output file path. May overwrite your original PSB files!", CommandOptionType.SingleValue);
                 //args
                 var argPsbPaths = archiveCmd.Argument("PSB", "Archive Info PSB .json paths", true);
 
@@ -518,7 +520,7 @@ Example:
                 Console.WriteLine($"Compile {name} failed.\r\n{e}");
             }
 
-            Console.WriteLine(!string.IsNullOrEmpty(outputPath)? $"Compile output: {savePath}" : $"Compile {name} done.");
+            Console.WriteLine(!string.IsNullOrEmpty(outputPath) ? $"Compile output: {savePath}" : $"Compile {name} done.");
         }
 
         private static string PrintHelp()


### PR DESCRIPTION
修复 PsbDecompiler.cs 生成的 resx.json 不在 output 文件夹以及 PsBuild 添加 output 选项报错的问题。